### PR TITLE
WIP: add talk functions

### DIFF
--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -422,7 +422,6 @@ class Module(ProjectAliceObject):
 		if replace:
 			talk = talk.format(*replace)
 		return talk
-		
 
 
 	def getModuleInstance(self, moduleName: str) -> Module:

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -413,13 +413,16 @@ class Module(ProjectAliceObject):
 		return self.DatabaseManager.insert(tableName=tableName, query=query, values=values, callerName=self.name)
 
 
-	def randomTalk(self, text: str, replace: list = None) -> str:
-		string = self.TalkManager.randomTalk(talk=text, module=self.name)
+	def randomTalk(self, text: str, replace: list = None, **kwargs) -> str:
+		talk = self.TalkManager.randomTalk(talk=text, module=self.name)
+
+		if Callable(talk):
+			talk(replace=replace, **kwargs)
 
 		if replace:
-			string = string.format(*replace)
-
-		return string
+			talk = talk.format(*replace)
+		return talk
+		
 
 
 	def getModuleInstance(self, moduleName: str) -> Module:

--- a/core/voice/TalkManager.py
+++ b/core/voice/TalkManager.py
@@ -89,7 +89,8 @@ class TalkManager(Manager):
 		return arr
 
 
-	def _selectSentence(self, talkData: dict, shortReplyMode: bool) -> Union[str, Callable]:
+	@staticmethod
+	def _selectSentence(talkData: dict, shortReplyMode: bool) -> Union[str, Callable]:
 		# when there is a mapping to a function add shortReplyMode as kwargs
 		if callable(talkData):
 			return partial(talkData, shortReplyMode=shortReplyMode)

--- a/core/voice/TalkManager.py
+++ b/core/voice/TalkManager.py
@@ -62,13 +62,13 @@ class TalkManager(Manager):
 						talkImport = importlib.import_module(f'modules.{moduleName}.talks.{lang}')
 						mappings = dict(getmembers(talkImport, isfunction))
 					else:
-						mapping = json.loads(langTalkFile.read_text())
+						mappings = json.loads(langTalkFile.read_text())
 
 					# there can be mappings both from json and py
 					if lang in self._langData[moduleName]:
-						self._langData[moduleName][lang].update(mapping)
+						self._langData[moduleName][lang].update(mappings)
 					else:
-						self._langData[moduleName][lang] = mapping
+						self._langData[moduleName][lang] = mappings
 				except ImportError as e:
 					self.logError(f"Couldn't import talk functions {moduleName}.talks.{lang}: {e}")
 					continue

--- a/tests/unittests/voice/test_TalkManager.py
+++ b/tests/unittests/voice/test_TalkManager.py
@@ -8,7 +8,7 @@ class TestTalkManager(unittest.TestCase):
 		talkManager = TalkManager()
 
 		# when short and default version exist
-		talkManager._langData = {
+		talkManager.langData = {
 			'module': {
 				'de': {
 					'talk': {
@@ -23,7 +23,7 @@ class TestTalkManager(unittest.TestCase):
 
 
 		# when only default version exists
-		talkManager._langData = {
+		talkManager.langData = {
 			'module': {
 				'de': {
 					'talk': {
@@ -36,7 +36,7 @@ class TestTalkManager(unittest.TestCase):
 
 
 		# when list instead of dict is used
-		talkManager._langData = {
+		talkManager.langData = {
 			'module': {
 				'de': {
 					'talk': ['defaultString']
@@ -47,7 +47,7 @@ class TestTalkManager(unittest.TestCase):
 
 
 		# when only fallback language exists
-		talkManager._langData = {
+		talkManager.langData = {
 			'module': {
 				'en': {
 					'talk': ['defaultString']
@@ -58,16 +58,16 @@ class TestTalkManager(unittest.TestCase):
 
 
 		# when required keys do not exist in active and fallback language
-		talkManager._langData = {'module': {'en': {}}}
+		talkManager.langData = {'module': {'en': {}}}
 		self.assertEqual(talkManager.chooseTalk('talk', 'module', 'de', 'en', True), '')
 
-		talkManager._langData = {'module': {'de': {}}}
+		talkManager.langData = {'module': {'de': {}}}
 		self.assertEqual(talkManager.chooseTalk('talk', 'module', 'de', 'en', True), '')
 
-		talkManager._langData = {'module': {}}
+		talkManager.langData = {'module': {}}
 		self.assertEqual(talkManager.chooseTalk('talk', 'module', 'de', 'en', True), '')
 
-		talkManager._langData = {}
+		talkManager.langData = {}
 		self.assertEqual(talkManager.chooseTalk('talk', 'module', 'de', 'en', True), '')
 
 


### PR DESCRIPTION
**This is still work in progress and untested**

the idea behind this is that normal talk sentences as used until now are not enough for some modules.
This enhancement allows the use of functions aswell.
e.g.
en.json
```
{
	"example1": ['string1'],
	"example2": ['string2']
}
```
de.json
```
{
	"example1": ['string1']
}
```
de.py
```
def example2(replace: list, shortReplyMode: bool, **kwargs) -> str:
    return 'fancy german grammar foo'
```

This way the concept gives an easy way to define functions to handle more complex answer handling (through kwargs it is possible to pass any additional parameters that might need to be passed). As shown above it is possible to use normal string mappings in one language and the function mapping in another language (because german grammar sucks a lot more often than english grammer xD)