### PR TITLE
do not call empty functions

### DIFF
--- a/core/base/SkillManager.py
+++ b/core/base/SkillManager.py
@@ -287,7 +287,7 @@ class SkillManager(Manager):
 			return None
 
 
-	def skillBroadcast(self, method: str, filterOut: list = None, silent: bool = False, *args, **kwargs):
+	def skillBroadcast(self, method: str, filterOut: list = None, *args, **kwargs):
 		"""
 		Broadcasts a call to the given method on every skill
 		:param filterOut: array, skills not to broadcast to
@@ -303,12 +303,10 @@ class SkillManager(Manager):
 				continue
 
 			try:
-				func = getattr(skillItem, method)
-				func(*args, **kwargs)
+				func = getattr(skillItem, method, None)
+				if func:
+					func(*args, **kwargs)
 
-			except AttributeError as e:
-				if not silent:
-					self.logWarning(f'Method "{method}" not found for skill "{skillItem.name}": {e}')
 			except TypeError:
 				# Do nothing, it's most prolly kwargs
 				pass

--- a/core/base/model/AliceSkill.py
+++ b/core/base/model/AliceSkill.py
@@ -335,6 +335,11 @@ class AliceSkill(ProjectAliceObject):
 		return self._supportedIntents[session.intentName][1](session=session)
 
 
+	def onMessage(self, session) -> bool:
+		""" Do not consume the intent by default """
+		return False
+
+
 	def getResource(self, skillName: str = '', resourcePathFile: str = '') -> Path:
 		return Path(self.Commons.rootDir(), 'skills', skillName or self.name, resourcePathFile)
 

--- a/core/base/model/ProjectAliceObject.py
+++ b/core/base/model/ProjectAliceObject.py
@@ -20,7 +20,7 @@ class ProjectAliceObject(Logger):
 		return json.dumps(self.__dict__)
 
 
-	def broadcast(self, method: str, exceptions: list = None, manager = None, propagateToSkills: bool = False, silent: bool = False, *args, **kwargs):
+	def broadcast(self, method: str, exceptions: list = None, manager = None, propagateToSkills: bool = False, *args, **kwargs):
 		if not exceptions:
 			exceptions = list()
 
@@ -45,95 +45,18 @@ class ProjectAliceObject(Logger):
 				continue
 
 			try:
-				func = getattr(man, method)
-				func(*args, **kwargs)
-			except AttributeError as e:
-				if not silent:
-					self.logWarning(f"Couldn't find method {method} in manager {man.name}: {e}")
+				func = getattr(skillItem, method, None)
+				if func:
+					func(*args, **kwargs)
 			except TypeError:
 				# Do nothing, it's most prolly kwargs
 				pass
 
 		if propagateToSkills:
-			self.SkillManager.skillBroadcast(method=method, silent=silent, *args, **kwargs)
+			self.SkillManager.skillBroadcast(method=method, *args, **kwargs)
 
 		for name in deadManagers:
 			del SM.SuperManager.getInstance().managers[name]
-
-
-	def onStart(self): pass
-	def onStop(self): pass
-	def onBooted(self): pass
-	def onSkillInstalled(self): pass
-	def onSkillUpdated(self): pass
-	def onInternetConnected(self): pass
-	def onInternetLost(self): pass
-	def onHotword(self, siteId: str, user: str = constants.UNKNOWN_USER): pass
-	def onHotwordToggleOn(self, siteId: str): pass
-	def onSessionStarted(self, session): pass
-	def onStartListening(self, session): pass
-	def onCaptured(self, session): pass
-	def onIntentParsed(self, session): pass
-	def onUserCancel(self, session): pass
-	def onSessionTimeout(self, session): pass
-	def onIntentNotRecognized(self, session): pass
-	def onSessionError(self, session): pass
-	def onSessionEnded(self, session): pass
-	def onSay(self, session): pass
-	def onSayFinished(self, session): pass
-	def onSessionQueued(self, session): pass
-
-	def onMessage(self, session) -> bool:
-		""" Do not consume the intent by default """
-		return False
-
-	def onSleep(self): pass
-	def onWakeup(self): pass
-	def onGoingBed(self): pass
-	def onLeavingHome(self): pass
-	def onReturningHome(self): pass
-	def onEating(self): pass
-	def onWatchingTV(self): pass
-	def onCooking(self): pass
-	def onMakeup(self): pass
-	def onContextSensitiveDelete(self, sessionId: str): pass
-	def onContextSensitiveEdit(self, sessionId: str): pass
-	def onFullMinute(self): pass
-	def onFiveMinute(self): pass
-	def onQuarterHour(self): pass
-	def onFullHour(self): pass
-	def onCancel(self): pass
-	def onASRCaptured(self): pass
-	def onWakeword(self, siteId: str, user: str = constants.UNKNOWN_USER): pass
-	def onMotionDetected(self): pass
-	def onMotionStopped(self): pass
-	def onButtonPressed(self): pass
-	def onButtonReleased(self): pass
-	def onDeviceConnecting(self): pass
-	def onDeviceDisconnecting(self): pass
-	def onUVIndexAlert(self, deviceList: list): pass
-	def onRaining(self, deviceList: list): pass
-	def onTooMuchRain(self, deviceList: list): pass
-	def onWindy(self, deviceList: list): pass
-	def onFreezing(self, deviceList: list): pass
-	def onTemperatureHighAlert(self, deviceList: list): pass
-	def onTemperatureLowAlert(self, deviceList: list): pass
-	def onCO2Alert(self, deviceList: list): pass
-	def onHumidityHighAlert(self, deviceList: list): pass
-	def onHumidityLowAlert(self, deviceList: list): pass
-	def onNoiseAlert(self, deviceList: list): pass
-	def onPressureHighAlert(self, deviceList: list): pass
-	def onPressureLowAlert(self, deviceList: list): pass
-	def onBroadcastingForNewDeviceStart(self, session): pass
-	def onBroadcastingForNewDeviceStop(self): pass
-	def onSnipsAssistantDownloaded(self, **kwargs): pass
-	def onSnipsAssistantDownloadFailed(self, **kwargs): pass
-	def onAuthenticated(self, session): pass
-	def onAuthenticationFailed(self, session): pass
-	def onAudioFrame(self, message): pass
-	def onSnipsAssistantInstalled(self, **kwargs): pass
-	def onSnipsAssistantFailedInstalling(self, **kwargs): pass
-	def onSkillInstallFailed(self, **kwargs): pass
 
 
 	@property


### PR DESCRIPTION
This removes the empty events from the ProjectAliceObject and therefor always checks if the functions is implemented and only when it is calls it.
This has multiple reasons:
- when the function just calls pass it has the same end result as not calling it at all
- The warning that it is not implemented is kind of useless anyways, since it only tells you that it is not implemented in the ProjectAliceObject, However it will not fail when it just passes -> does nothing
- calling functions is expensive. It takes around 20 times as long to call a function that just passes than to check if it exists
- the event handlers in the ProjectAliceObject got a big mess, since they included all events we currently have including the events from all skills, so it would get a bigger and bigger totally unmaintainable list, that gets added to anything derived from ProjectAliceObject

Skills that use events should list them in their README for now and later on we need to somehow extract them for the scenario stuff (I guess we can just extract them from the Readme aswell)