### PR TITLE
refactor Intent class to dataclass

### DIFF
--- a/core/asr/ASRManager.py
+++ b/core/asr/ASRManager.py
@@ -75,7 +75,7 @@ class ASRManager(Manager):
 			self.logDebug(f'{self._asr.__class__.__name__} output: "{result}"')
 
 			supportedIntents = session.intentFilter or self.SkillManager.supportedIntents
-			intentFilter = [intent.justTopic for intent in supportedIntents if isinstance(intent, Intent) and not intent.protected]
+			intentFilter = [intent.justTopic for intent in supportedIntents if isinstance(intent, Intent) and not intent.isProtected]
 
 			# Add Global Intents
 			intentFilter.append(Intent('GlobalStop').justTopic)

--- a/core/base/model/AliceSkill.py
+++ b/core/base/model/AliceSkill.py
@@ -108,8 +108,8 @@ class AliceSkill(ProjectAliceObject):
 
 				if item.fallbackFunction:
 					intents[str(item)].fallbackFunction = item.fallbackFunction
-				# always use the highest auth level specified
-				if item.authOnly > intents[str(item)].authOnly:
+				# always use the highest auth level specified (low values mean a higher auth level)
+				if item.authOnly < intents[str(item)].authOnly:
 					intents[str(item)].authOnly = item.authOnly
 			else:
 				intents[str(item)] = item
@@ -134,8 +134,8 @@ class AliceSkill(ProjectAliceObject):
 				else:
 					intentMappings[str(intent)].fallbackFunction = function
 
-				# always use the highes auth level specified
-				if intent.authOnly > intentMappings[str(intent)].authOnly:
+				# always use the highest auth level specified (low values mean a higher auth level)
+				if intent.authOnly < intentMappings[str(intent)].authOnly:
 					intentMappings[str(intent)].authOnly = intent.authOnly
 
 		return intentMappings
@@ -206,9 +206,9 @@ class AliceSkill(ProjectAliceObject):
 
 		#TODO: either typing in function definition is wrong, or it is always a Intent
 		if isinstance(intent, tuple):
-			check = intent[0].justAction
+			check = intent[0].action
 		elif isinstance(intent, Intent):
-			check = intent.justAction
+			check = intent.action
 		else:
 			check = str(intent).split('/')[-1].split(':')[-1]
 

--- a/core/user/model/AccessLevels.py
+++ b/core/user/model/AccessLevels.py
@@ -3,6 +3,7 @@ from enum import IntEnum, unique
 
 @unique
 class AccessLevel(IntEnum):
+	ZERO = 0
 	ADMIN = 1
 	DEFAULT = 2
 	KID = 3


### PR DESCRIPTION
Changes:
- this makes the IntentClass a dataclass.
A big advantage of the change is that for debugging purposes it is now possible to simply print a Intent, while so far it would throw an exception since it was derived from logger. This was especially painful when debugging errors in the dialog flow.
```
print(Intent('exampleIntent'))
Intent(topic='hermes/intent/example:exampleIntent', protected=False, userIntent=True, authOnly=<AccessLevel.ZERO: 0>, fallbackFunction=None, dialogMapping={})
```


- fixes a bug in the dialog flow where it would always use the lowest auth level

TODO:
- some mocking stuff in the unit tests needs to be update, since it using SuperManager directly now
