### PR TITLE
Bad indentation, skills with only slotTypes issue

### DIFF
--- a/core/nlu/model/SnipsNlu.py
+++ b/core/nlu/model/SnipsNlu.py
@@ -90,8 +90,8 @@ class SnipsNlu(NluEngine):
 				# noinspection PyTypeChecker
 				nluTrainingSample['intents'][intentName]['utterances'].append({'data': data})
 
-			with Path(self._cachePath, f'{dialogTemplate["skill"]}_{file.stem}.json').open('w') as fp:
-				json.dump(nluTrainingSample, fp, ensure_ascii=False, indent=4)
+		with Path(self._cachePath, f'{dialogTemplate["skill"]}_{file.stem}.json').open('w') as fp:
+			json.dump(nluTrainingSample, fp, ensure_ascii=False, indent=4)
 
 
 	def train(self):


### PR DESCRIPTION
Bad indentation, datasets for skills with only slotTypes are not generated. Skill dataset was overwritten for each intent.