### PR TITLE
Error capturing for hotword not loading

### DIFF
--- a/core/voice/model/SnipsWakeword.py
+++ b/core/voice/model/SnipsWakeword.py
@@ -28,4 +28,6 @@ class SnipsWakeword(WakewordEngine):
 
 	def onStart(self):
 		super().onStart()
-		self.Commons.runRootSystemCommand(['systemctl', 'start', 'snips-hotword'])
+		result = self.Commons.runRootSystemCommand(['systemctl', 'start', 'snips-hotword'])
+		if result.returncode:
+			self.logWarning(f'Error: {result.stderr}')


### PR DESCRIPTION
##### Summary

Just added a warning if hotword fails to load. Currently there is no notification for this so the user would be none the wiser if the snips-hotword failed to start other than not being able to trigger a hotword. This would just help with diagnosis

If snips-hotword starts normally, no message displayed ( as it is now)
If snips-hotword fails to start, display message in system log


##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring
- [x] Other, please describe: - additional notification code

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [ ] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [x] You have tested your changes on the branch you wish to merge
- [x] The changes are working


If adding a **new feature**, the PR's description includes:

- [ ] The reason for this new feature to be added
- [ ] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information:
