### PR TITLE
add aliceIp to the params of the alice device

### DIFF
--- a/core/device/DeviceManager.py
+++ b/core/device/DeviceManager.py
@@ -90,6 +90,8 @@ class DeviceManager(Manager):
 		elif self.ConfigManager.getAliceConfigByName('disableCapture'):
 			device.setAbilities([DeviceAbility.IS_CORE, DeviceAbility.PLAY_SOUND])
 
+		device.updateParams(key='aliceIp', value=self.Commons.getLocalIp())
+
 		for device in self._devices.values():
 			device.onStart()
 


### PR DESCRIPTION
##### Summary

Can we add this to alices deviceParams ? 

Handy for when wanting to reference alices actual Ip address from a satellite and the user has localhost set as mqttServer for example. And could be handy for many references i guess 

##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring
- [x] Other, please describe: new param for alice

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [ ] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [x] You have tested your changes on the branch you wish to merge
- [x] The changes are working


If adding a **new feature**, the PR's description includes:

- [ ] The reason for this new feature to be added
- [ ] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information:
