### PR TITLE
Temp fix for no uid error. (refer Todo's)

### DIFF
--- a/core/util/AliceWatchManager.py
+++ b/core/util/AliceWatchManager.py
@@ -54,6 +54,10 @@ class AliceWatchManager(Manager):
 
 
 	def onSessionStarted(self, session: DialogSession):
+		#todo @psycho - Some situations like self.ask() from gui (addUser) theres no session.deviceUid
+		# which results in getMainDevice().uid being None. the below is a temp fix
+		if not session.deviceUid:
+			session.deviceUid = self.DeviceManager.getMainDevice().uid
 		self.publish(payload={
 			'text': f'Session with id "**{session.sessionId}**" was started on device **{self.DeviceManager.getDevice(uid=session.deviceUid).displayName}**',
 			'component': 'Dialogue',
@@ -153,6 +157,10 @@ class AliceWatchManager(Manager):
 
 
 	def onSessionEnded(self, session: DialogSession):
+		#todo @psycho - Some situations like self.ask() from gui (addUser) theres no session.deviceUid
+		# which results in getMainDevice().uid being None. the below is a temp fix
+		if not session.deviceUid:
+			session.deviceUid = self.DeviceManager.getMainDevice().uid
 		text = f'Session with id "**{session.sessionId}**" was ended on device **{self.DeviceManager.getDevice(uid=session.deviceUid).displayName}**.'
 
 		reason = session.payload['termination']['reason']


### PR DESCRIPTION
##### Summary

temporary fix for situations like this 
```File "/home/khadas/ProjectAlice/core/util/AliceWatchManager.py", line 156, in onSessionEnded
Feb  8 20:13:31 localhost python[10236]:     text = f'Session with id "**{session.sessionId}**" was ended on device **{self.DeviceManager.getDevice(uid=session.deviceUid).displayName}**.'
Feb  8 20:13:31 localhost python[10236]: AttributeError: 'NoneType' object has no attribute 'displayName'
```

##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring
- [ ] Other, please describe:

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [ ] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [ ] You have tested your changes on the branch you wish to merge
- [ ] The changes are working


If adding a **new feature**, the PR's description includes:

- [ ] The reason for this new feature to be added
- [ ] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information:

Temporary fix - suspect this needs more investigation in the background ?