### PR TITLE
Give Alice a name

### DIFF
--- a/core/base/ConfigManager.py
+++ b/core/base/ConfigManager.py
@@ -176,8 +176,9 @@ class ConfigManager(Manager):
 
 	def updateMainDeviceName(self, value: typing.Any):
 		device = self.DeviceManager.getMainDevice()
+
 		if not device.displayName:
-			device.updateConfigs(configs={'displayName': "default"})
+			device.updateConfigs(configs={'displayName': "Alice"})
 		if value != device.displayName:
 			device.updateConfigs(configs={'displayName': value})
 

--- a/core/device/DeviceManager.py
+++ b/core/device/DeviceManager.py
@@ -74,7 +74,7 @@ class DeviceManager(Manager):
 		# Create the default core device if needed. Cannot be done in AliceCore skill due to load sequence
 		device = self.getMainDevice()
 		if not device:
-			device = self.addNewDevice(deviceType='AliceCore', skillName='AliceCore', locationId=1)
+			device = self.addNewDevice(deviceType='AliceCore', skillName='AliceCore', locationId=1, displayName="Alice")
 			if not device:
 				self.logFatal('Core unit device creation failed, cannot continue')
 				return
@@ -82,6 +82,8 @@ class DeviceManager(Manager):
 			self.logInfo('Created main unit device')
 			self.ConfigManager.updateAliceConfiguration('uuid', device.uid)
 
+		if not device.displayName:
+			device.updateConfigs(configs={'displayName': "Alice"})
 
 		if self.ConfigManager.getAliceConfigByName('disableSound') and self.ConfigManager.getAliceConfigByName('disableCapture'):
 			device.setAbilities([DeviceAbility.IS_CORE]) #Remove default abilities


### PR DESCRIPTION
##### Summary

Give alice a name on creation .(default name = "Alice")
Currently her name remains "null" unless admin save button is clicked. So added her name on startup now if it doesnt exist as well

otherwise self.getMainDevice().displayName syslog message will end up empty for that value ?


##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring
- [ ] Other, please describe:

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [ ] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [x] You have tested your changes on the branch you wish to merge
- [x] The changes are working


If adding a **new feature**, the PR's description includes:

- [ ] The reason for this new feature to be added
- [ ] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information:
