### PR TITLE
update: minimise Amazon Polly TTS read timeout further and bump boto3. Issue #453

### DIFF
--- a/core/asr/model/AmazonAsr.py
+++ b/core/asr/model/AmazonAsr.py
@@ -32,7 +32,7 @@ class AmazonAsr(Asr):
 	DEPENDENCIES = {
 		'system': [],
 		'pip': 	  {
-			'boto3==1.17.84'
+			'boto3==1.17.85'
 		}
 	}
 

--- a/core/voice/model/AmazonTts.py
+++ b/core/voice/model/AmazonTts.py
@@ -35,7 +35,7 @@ except ModuleNotFoundError:
 # boto3.set_stream_logger('', 10) # enable this to debug boto3
 
 AWS_CONF_CONNECT_TIMEOUT = 10
-AWS_CONF_READ_TIMEOUT = 5
+AWS_CONF_READ_TIMEOUT = 1
 AWS_CONF_MAX_POOL_CONNECTIONS = 1
 
 
@@ -45,8 +45,8 @@ class AmazonTts(Tts):
 	DEPENDENCIES = {
 		'system': [],
 		'pip': {
-			'botocore==1.20.84',
-			'boto3==1.17.84'
+			'botocore==1.20.85',
+			'boto3==1.17.85'
 		}
 	}
 


### PR DESCRIPTION
<!-- Please don't delete this template!! -->

<!-- (Change "[ ]" to "[x]" to check a box) -->

- upgrade to latest boto3 1.17.85 & botocore 1.20.85
  This also adds French Canadian nueral voice. see boto3 changelog.
- change AWS_CONF_READ_TIMEOUT from 5 sec to 1 sec.

<!-- Please summarize your Pull Request -->

##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring
- [x] Other, please describe:

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [x] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [x] You have tested your changes on the branch you wish to merge
- [x] The changes are working


If adding a **new feature**, the PR's description includes:

- [ ] The reason for this new feature to be added
- [ ] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information:
